### PR TITLE
blog: Pinecones and the Portable Certificate

### DIFF
--- a/blog/factor-graphs-for-langgraph-gates/index.html
+++ b/blog/factor-graphs-for-langgraph-gates/index.html
@@ -232,6 +232,7 @@
                 <li><a href="https://github.com/coredipper/operon/blob/main/article/paper6/sections/08-factor-graphs.tex">Paper 6 appendix &sect;8</a> &mdash; the full term-by-term mapping, worked example with real seed-0 numbers, and an explicit record of where the analogy stops</li>
                 <li><a href="https://gtsam.org/2026/04/21/factor-graphs-and-world-models.html">Dellaert, &ldquo;Factor Graphs and World Models&rdquo;</a> &mdash; the GTSAM post this one is written in reply to</li>
                 <li><a href="https://huggingface.co/spaces/coredipper/operon-stagnation-gate">StagnationGate demo on HuggingFace Spaces</a></li>
+                <li><a href="/blog/pinecones-and-the-portable-certificate/">Pinecones and the Portable Certificate</a> &mdash; companion cross-domain post: a materials-engineering preprint reaches the same compositional-verification framework, one layer up at the theorem level rather than the mechanism level</li>
             </ul>
 
             <div class="footer">

--- a/blog/pinecones-and-the-portable-certificate/index.html
+++ b/blog/pinecones-and-the-portable-certificate/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pinecones and the Portable Certificate - Bogdan Banu</title>
+    <style>
+        ::selection { background: #505050; }
+        ::-moz-selection { background: #505050; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { background-color: #000; }
+        body {
+            background-color: #0a0a0a;
+            color: #d0d0d0;
+            font-family: 'Georgia', 'Times New Roman', serif;
+            line-height: 1.8;
+            font-size: 17px;
+        }
+        .container {
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 60px 24px 120px;
+        }
+        nav {
+            margin-bottom: 48px;
+            font-family: 'SF Mono', 'Monaco', monospace;
+        }
+        nav a {
+            color: #888;
+            text-decoration: none;
+            font-size: 14px;
+            transition: color 0.2s;
+        }
+        nav a:hover { color: #fff; }
+        header {
+            text-align: center;
+            margin-bottom: 48px;
+            padding-bottom: 32px;
+            border-bottom: 1px solid #222;
+        }
+        h1 {
+            font-size: 28px;
+            font-weight: 600;
+            color: #fff;
+            margin-bottom: 12px;
+            line-height: 1.3;
+        }
+        .subtitle {
+            font-size: 16px;
+            color: #888;
+            margin-bottom: 16px;
+            font-style: italic;
+        }
+        .author {
+            font-size: 15px;
+            color: #999;
+            font-family: 'SF Mono', monospace;
+        }
+        .author a {
+            color: #999;
+            text-decoration: none;
+            border-bottom: 1px solid #444;
+        }
+        .author a:hover {
+            color: #fff;
+            border-color: #888;
+        }
+        .version-note {
+            display: inline-block;
+            margin-top: 12px;
+            padding: 4px 12px;
+            background: #1a2a1a;
+            border-radius: 4px;
+            font-size: 12px;
+            color: #6a6;
+            font-family: 'SF Mono', monospace;
+        }
+        h2 {
+            font-size: 22px;
+            font-weight: 600;
+            color: #fff;
+            margin: 48px 0 24px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #222;
+        }
+        p {
+            margin-bottom: 16px;
+            text-align: justify;
+        }
+        ul, ol {
+            margin: 16px 0 16px 24px;
+        }
+        li {
+            margin-bottom: 8px;
+        }
+        code {
+            font-family: 'SF Mono', 'Monaco', monospace;
+            font-size: 0.9em;
+            background: #111;
+            padding: 2px 5px;
+            border-radius: 3px;
+        }
+        blockquote {
+            margin: 32px 0;
+            padding: 16px 24px;
+            border-left: 3px solid #333;
+            color: #b0b0b0;
+            font-style: italic;
+        }
+        a {
+            color: #8ab4f8;
+            text-decoration: none;
+        }
+        a:hover { text-decoration: underline; }
+        .footer {
+            margin-top: 80px;
+            padding-top: 24px;
+            border-top: 1px solid #222;
+            font-size: 14px;
+            color: #666;
+            font-family: 'SF Mono', monospace;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <nav>
+            <a href="/blog/">&larr; Blog</a>
+        </nav>
+
+        <article>
+            <header>
+                <h1>Pinecones and the Portable Certificate</h1>
+                <div class="subtitle">A materials-engineering preprint from MIT just made the substrate-independence move explicit. The Operon papers have been making the same move silently for five iterations &mdash; here is what we can borrow from how they did it.</div>
+                <div class="author"><a href="/">Bogdan Banu</a> &middot; April 27, 2026</div>
+                <div class="version-note">cross-domain methodology note</div>
+            </header>
+
+            <p>A mechanical-engineering preprint about pinecones and 4D-printed bilayer composites just stated, in materials-engineering prose, the principle that has been quietly load-bearing across all five Operon papers.</p>
+
+            <p>The preprint is Marom, Tibbits, Zardini, and Buehler, <a href="https://arxiv.org/abs/2604.26367"><em>A Category-Theoretic Framework from Biological Mechanics to Engineered Stimulus-Response Systems</em></a> (arXiv:2604.26367, posted two days ago, MIT, <code>cond-mat.soft</code>). It is not about agents, not about LLMs, not about software at all. It is about taking a biological mechanism &mdash; a hygromorphic pinecone whose scales open and close with humidity &mdash; and translating it into a 4D-printed bilayer composite that does the same thing under the same stimulus, then certifying that the translation preserves the mechanics scale by scale.</p>
+
+            <p>The interesting part is not the pinecone. The interesting part is the sentence on page 2:</p>
+
+            <blockquote>Two systems that share the same compositional structure, such as a biological material hierarchy and an engineered one, can be related by a functor that preserves the interface logic at every scale <strong>without requiring that the two domains share any physical substrate</strong>.</blockquote>
+
+            <p>That is the materials-engineering version of the load-bearing claim Operon has been making for five papers: harness-level structural certificates are model-independent and framework-portable. Their pinecone is cellulose, hygromorphic, water-driven. Their 4D-printed bilayer is polymer (PA6-GF and PA612-CF), thermomorphic, heat-driven. Zero shared physical substrate. Yet a functor relates them, and the functor preserves the dynamics scale by scale, and the closure of that preservation property under composition is the load-bearing theorem of the paper.</p>
+
+            <p>That is the same move Operon makes between an LLM agent and a Python LangGraph runtime. Transformer weights and Python AST share zero substrate. The certificate functor relates them anyway, by interface logic alone.</p>
+
+            <h2>Connected to: the SLAM-already-solved-stagnation post</h2>
+
+            <p>If you read <a href="/blog/factor-graphs-for-langgraph-gates/">SLAM Already Solved Stagnation</a> from a few days ago, you saw an argument that the structural pattern Operon&rsquo;s pre-/post-guard implements is not new &mdash; it is a discrete-state port of factor-graph fixed-lag smoothing from robotics SLAM, formalised by Kaess et al. and recently re-framed by Dellaert as STAG. That post grounds the gates wedge by pointing at the right citation lineage.</p>
+
+            <p>This post is the same kind of grounding, one layer up. SLAM tells us we have the right <em>mechanism</em>. Marom-Buehler tell us we have the right <em>theorem</em>. Both groundings come from outside the LLM-agent literature, which is the point: if the structural claim is real, it should not depend on the substrate it is being claimed about.</p>
+
+            <h2>The mapping, term by term</h2>
+
+            <p>I want to do this concretely, because the cleanness is the point. Their construction is in section 2 of the preprint; Operon&rsquo;s is across Paper 5 sections 3&ndash;4 and the <code>operon_ai/convergence/guarded_graph.py</code> module.</p>
+
+            <p><strong>Their category Dyn.</strong> Objects are triples <code>S = (X, E, f)</code>: a state space, an environment (stimulus) space, and a governing law that says how the state evolves under the stimulus. Morphisms are pairs <code>(&alpha;, &alpha;_E)</code> on states and stimuli respectively, satisfying a simulation condition (their equation 3) that forces the morphism to commute with time evolution: evolving at the fine scale and then mapping is the same as mapping and then evolving at the coarse scale. Composition is automatic from this property.</p>
+
+            <p><strong>Operon&rsquo;s analogue.</strong> A <code>StateGraph</code> in LangGraph parlance is a triple of (state schema, input/environment, node-set as dynamics). The morphisms are behavior-preserving rewirings &mdash; the kind <code>compile_guarded_graph</code> produces when it lifts a guarded specification to an executable graph. The simulation condition is that the certificate predicate holds before and after the rewriting. Their Eq. 3 is, in our vocabulary, &ldquo;<code>Certificate.verify</code> commutes with <code>compile_guarded_graph</code>.&rdquo;</p>
+
+            <p><strong>Their subcategories Nat and Art.</strong> Both natural systems (biology) and engineered systems (4D printing) live as subcategories of the <em>same</em> parent <code>Dyn</code>. The implementation functor <code>F: Nat &rarr; Art</code> is internal &mdash; it goes between siblings of one shared parent. That gives composition and identity for free, with no need to redefine them across two unrelated categories.</p>
+
+            <p><strong>Operon&rsquo;s analogue, sort of.</strong> We currently treat the spec category and the runtime category as two separate things, with <code>compile_guarded_graph</code> as the bridge. That works. But the parent-category framing &mdash; let&rsquo;s call it <code>GuardedSys</code> &mdash; would let <code>compile_guarded_graph</code> be an internal endo-style functor inheriting structure for free, exactly the way Marom-Buehler get composition for free in <code>Dyn</code>. This is the first borrowable move.</p>
+
+            <p><strong>Their Spec category and projection &pi;.</strong> Between the behavioural target in <code>Art</code> and the actual machine instructions in <code>Comp</code>, they put an intermediate category <code>Spec</code> of fabrication programs &mdash; part domain plus an ordered sequence of deposition primitives. The projection <code>&pi;: Spec &rarr; Art</code> maps each program to the behaviour it predicts. The pre-image <code>&pi;<sup>&minus;1</sup>(A)</code> is the <em>fabrication design space</em> for target <code>A</code>: every program that produces the same predicted behaviour. Their process windows <code>I_k</code> are sub-objects of <code>&pi;<sup>&minus;1</sup>(A)</code> &mdash; the ranges over which a process parameter can vary while still landing in the same equivalence class.</p>
+
+            <p><strong>Operon&rsquo;s analogue, currently implicit.</strong> The set of all certificate-preserving compilations of a guarded graph for a fixed certificate <code>C</code> is exactly <code>&pi;<sup>&minus;1</sup>(C)</code> in their idiom. Right now we reason about it informally (&ldquo;any caller satisfying signature S yields a cert-equivalent run&rdquo;). Their construction makes this a first-class object: <code>&pi;<sup>&minus;1</sup>(C)</code> with input/parameter-validity bands as sub-objects. Cleaner equivalence-class semantics. Second borrowable move.</p>
+
+            <p><strong>Closure as a single property.</strong> Their headline theorem is that the simulation condition is closed under composition. Once you prove that for the morphism class, every chain of locally valid scale transitions inherits validity. They do not re-prove closure per scale.</p>
+
+            <p><strong>Operon&rsquo;s analogue.</strong> We currently state preservation per certificate family &mdash; one for <code>behavioral_stability_windowed</code>, another for <code>langgraph_state_integrity</code>, another for <code>dna_repair</code>. That is fine for two theorems and gets uncomfortable at five. The borrowable move is to restate the master claim once: &ldquo;is a cert-preserving morphism in <code>GuardedSys</code>&rdquo; is closed under composition, and individual theorems instantiate it. Easier to adopt now than later.</p>
+
+            <h2>The five borrowable moves, with honest labels</h2>
+
+            <p>Calling these M1 through M5 because that is how they are tagged in the reference memory and the plan file. Honest labels: <em>adopt now</em>, <em>defer to Paper 5 v2</em>, or <em>empirical-demo TODO</em>. None of them are done yet.</p>
+
+            <ul>
+                <li><strong>M1: parent-category framing.</strong> Put <code>Spec</code> and <code>Runtime</code> as siblings of one <code>GuardedSys</code>; <code>compile_guarded_graph</code> becomes an internal functor. <em>Defer to Paper 5 v2.</em> No code change required, just exposition.</li>
+                <li><strong>M2: naturally-forced simulation condition.</strong> Audit whether Operon&rsquo;s preservation property is forced by definitional unrolling of <code>Certificate.verify</code> over rewrites, or bolted-on as a separate axiom. If forced, say so explicitly in Paper 5 &sect;4. If bolted-on, find the natural source. <em>Adopt now.</em> One paragraph, possibly two.</li>
+                <li><strong>M3: first-class equivalence-class object.</strong> Make <code>&pi;<sup>&minus;1</sup>(C)</code> a first-class type-level object with parameter-validity bands as sub-objects. <em>Defer to Paper 5 v2 &mdash; affects type signatures.</em> Plus a small doc-comment refactor in <code>operon_ai/core/certificate.py</code>.</li>
+                <li><strong>M4: closure as a single property.</strong> Restate preservation once at the master-property level; let theorems instantiate. <em>Adopt now &mdash; while we have only two theorems shipped, this is cheap. Two theorems from now, it gets expensive.</em></li>
+                <li><strong>M5: generative compositionality demo.</strong> Their 2&times;2 family has one design (thermal twisting) that arises <em>only</em> by composition of components validated for other products &mdash; never derived independently. We can mirror this: two cert-emitting gates &times; two graph topologies, arranged so one configuration is reachable only by composing pieces validated for other graphs. Falsifiable empirical claim that compositionality of certificates is generative, not just closed. <em>Empirical-demo TODO &mdash; new test case in <code>operon-langgraph-gates</code> or the operon repo.</em></li>
+            </ul>
+
+            <h2>What I am not claiming</h2>
+
+            <p>I want to mark the bound clearly because the analogy is neat enough to invite overreach.</p>
+
+            <ul>
+                <li><strong>I am not claiming the two frameworks are mathematically equivalent.</strong> They are structurally identical at the level of compositional logic and the substrate-independence principle. That is a real and useful kinship. It is not the same as a categorical equivalence, and I have not written down such a functor.</li>
+                <li><strong>I am not claiming Operon&rsquo;s certificates are physically realised.</strong> Marom-Buehler fabricate their bilayers and measure them. We do not. Their framework is substrate-validated; Operon&rsquo;s is property-validated. Both have honest standing on their own terms. The shared piece is the compositional structure; the validation cultures differ.</li>
+                <li><strong>I am not claiming any of M1&ndash;M5 is done.</strong> The reference memory entry catalogues them as future-revision agenda for Paper 5 v2 or a follow-up. Today they are a borrowable list; nothing is adopted yet.</li>
+                <li><strong>I am not claiming this paper changes the wedge.</strong> <code>operon-langgraph-gates</code> v0.1 ships <code>StagnationGate</code> and <code>IntegrityGate</code>; that scope is fixed and unchanged. This post is paper-track and methodology-track, not wedge-scope.</li>
+            </ul>
+
+            <h2>What it does get us</h2>
+
+            <p>Cross-domain corroboration of the load-bearing claim. The thing that has been hard to defend, when people read the Operon papers in isolation, is that the substrate-independence move is real and not a pet abstraction of the LLM-agent setting. Pinecones do not have an LLM-agent setting. They reach the same compositional framework anyway, by attacking a fundamentally different problem, with a fundamentally different validation culture, and they articulate the substrate-independence principle <em>more clearly than we have</em> in any of the five papers so far.</p>
+
+            <p>That is the kind of cross-domain hit that should reduce the prior on &ldquo;this is just an LLM-internal trick.&rdquo; If the same structural framework keeps falling out when you push hard on compositional verification &mdash; whether you are translating biology to 4D printing, or specifying agent harnesses with categorical morphisms &mdash; the framework is doing real work. The load-bearing claim survives an independent test.</p>
+
+            <p>The methodology-emulation list (M1&ndash;M5) is the second-order benefit. Marom-Buehler made five specific construction moves we did not, and three of them (M1, M3, M4) sharpen Paper 5&rsquo;s exposition without changing the runtime. That is exactly the kind of borrowing that earns its keep: small surface area, low risk, and it makes the next paper or revision read tighter.</p>
+
+            <h2>Links</h2>
+
+            <ul>
+                <li><a href="https://arxiv.org/abs/2604.26367">Marom, Tibbits, Zardini, Buehler, <em>A Category-Theoretic Framework from Biological Mechanics to Engineered Stimulus-Response Systems</em></a> (arXiv:2604.26367)</li>
+                <li><a href="https://github.com/coredipper/operon/blob/main/article/paper5/main.pdf">Paper 5 &mdash; <em>Harness Engineering as Categorical Architecture</em></a>, where the preservation theorem and now the cross-domain corroboration paragraph live</li>
+                <li><a href="/blog/factor-graphs-for-langgraph-gates/">SLAM Already Solved Stagnation</a> &mdash; the companion cross-domain post grounding the wedge mechanism in robotics</li>
+                <li><a href="https://github.com/coredipper/operon-langgraph-gates"><code>operon-langgraph-gates</code> on GitHub</a> &mdash; the wedge that this whole methodology eventually serves</li>
+            </ul>
+
+            <div class="footer">
+                <a href="/blog/">&larr; Back to blog</a>
+            </div>
+        </article>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New cross-domain methodology blog post on Marom, Tibbits, Zardini, Buehler arXiv:2604.26367 (MIT cond-mat.soft, 2026-04-29). The post grounds Operon's substrate-independence claim — load-bearing across five papers — in materials-engineering prose, articulates the M1–M5 methodology-emulation playbook (parent-category framing, naturally-forced simulation condition, first-class equivalence-class object, closure as a single property, generative compositionality demo), and marks honest scope bounds (substrate-validated vs property-validated; M1–M5 are borrowable candidates, not adopted yet).
- Bidirectional thread with the factor-graphs post: factor-graphs grounds the wedge mechanism in robotics SLAM (one layer down); pinecones grounds the preservation theorem in materials engineering (one layer up). Both are non-LLM corroborations of the same load-bearing claim.
- Adds a one-line "see also" entry to the factor-graphs post pointing back at this one. The two posts now constitute a navigable cross-domain constellation.
- Pure HTML, dark theme, ~1500 words, styling matches the factor-graphs precedent verbatim (CSS reused).

## Test plan
- [ ] Open `blog/pinecones-and-the-portable-certificate/index.html` in a browser; confirm dark theme renders, code spans use monospace, blockquote on the substrate-independence quote is styled
- [ ] Click the see-also link inside the new post → arrives at factor-graphs post
- [ ] Click the see-also link inside the factor-graphs post → arrives back at the new post
- [ ] Confirm honest-bound section ("What I am not claiming") explicitly disclaims mathematical equivalence and substrate-equivalence, and labels each M1–M5 move as adopt/defer/TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)