### PR TITLE
blog: factor-graphs post version-note → v0.1.0 stable

### DIFF
--- a/blog/factor-graphs-for-langgraph-gates/index.html
+++ b/blog/factor-graphs-for-langgraph-gates/index.html
@@ -133,7 +133,7 @@
                 <h1>SLAM Already Solved Stagnation</h1>
                 <div class="subtitle"><code>operon-langgraph-gates</code> v0.1 is a discrete-state port of factor-graph fixed-lag smoothing (Kaess 2012). The port is trivial &mdash; the scope discipline that falls out is the upgrade.</div>
                 <div class="author"><a href="/">Bogdan Banu</a> &middot; April 23, 2026</div>
-                <div class="version-note">operon-langgraph-gates v0.1 (alpha)</div>
+                <div class="version-note">operon-langgraph-gates v0.1.0 (stable, 2026-04-30)</div>
             </header>
 
             <p>A LangGraph user filed <a href="https://github.com/langchain-ai/langgraph/issues/6731">issue #6731</a> asking for protection against infinite agent loops. It was closed, not as <em>wontfix</em>, but as NOT_PLANNED &mdash; out of scope for the framework.</p>


### PR DESCRIPTION
## Summary
- Update the version-note element on the [factor-graphs-for-langgraph-gates](https://coredipper.github.io/blog/factor-graphs-for-langgraph-gates/) post from "(alpha)" to "(stable, 2026-04-30)".
- Post was written April 23, 2026 — 7 days before v0.1.0 stable shipped — so the qualifier was correct at publication and stale by week's end.
- Body text untouched (preserves temporal honesty); only the live version-note element gets the current label.

## Context
Final cosmetic leg of the v0.1.0 stable cutover, after `langchain-ai/langgraph#6731` comment edit, HF Space `requirements.txt` bump (operon-langgraph-gates PR #20), and README "Stability commitment" rewrite (operon-langgraph-gates PR #21).

## Test plan
- [ ] After merge: visit https://coredipper.github.io/blog/factor-graphs-for-langgraph-gates/ and confirm the version-note line reads "operon-langgraph-gates v0.1.0 (stable, 2026-04-30)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)