### PR TITLE
blog: cite arXiv:2605.15225 in the Paper 4 narrative post

### DIFF
--- a/blog/operon-structural-guarantees/index.html
+++ b/blog/operon-structural-guarantees/index.html
@@ -151,8 +151,10 @@
                 <h1>What Biological Agent Design Actually Buys You</h1>
                 <div class="subtitle">After benchmarking three operon subsystems against naive alternatives, the honest answer is: structural guarantees, not algorithmic sophistication</div>
                 <div class="author"><a href="/">Bogdan Banu</a> &middot; April 4, 2026</div>
-                <div class="version-note">operon-ai v0.27.1</div>
+                <div class="version-note">operon-ai v0.27.1 &middot; <a href="https://arxiv.org/abs/2605.15225" style="color:#6a6;border:none;">arXiv:2605.15225</a></div>
             </header>
+
+            <p><em><strong>Update (May 2026):</strong> the three benchmarks below are now written up formally &mdash; <a href="https://arxiv.org/abs/2605.15225"><em>Do Biological Structural Guarantees Earn Their Complexity?</em></a> (arXiv:2605.15225), with a Gemma&nbsp;4 27B end-to-end follow-up confirming the split this post describes: state-integrity guarantees are deterministic, behavioral and output-layer guarantees show honest limitations with capable models. This post is the narrative companion; the paper carries the full methodology and the conditional-guarantee analysis.</em></p>
 
             <h2>The biological stack</h2>
 
@@ -249,6 +251,7 @@
             </ul>
 
             <ul>
+                <li><a href="https://arxiv.org/abs/2605.15225">Paper &mdash; <em>Do Biological Structural Guarantees Earn Their Complexity?</em></a> (arXiv:2605.15225) &mdash; the formal write-up of this post&rsquo;s benchmarks.</li>
                 <li><a href="https://github.com/coredipper/operon">GitHub</a></li>
                 <li><a href="https://pypi.org/project/operon-ai/">PyPI</a></li>
                 <li><a href="https://banu.be/operon">Docs</a></li>


### PR DESCRIPTION
## Summary

Paper 4 — [*Do Biological Structural Guarantees Earn Their Complexity?*, arXiv:2605.15225](https://arxiv.org/abs/2605.15225) — posted to arXiv 2026-05-13. Its **narrative companion blog post already exists**: `blog/operon-structural-guarantees/` ("What Biological Agent Design Actually Buys You", Apr 4 2026) — same thesis, same three benchmarks, same 10M-data-point methodology. It predated the paper and carried no citation.

Rather than write a duplicate post, this wires the arXiv ID into the existing one (same approach as the `banu2026benchmarks` bib-key fix in operon PR #180 — one canonical artifact per work):

- **version-note**: appends the `arXiv:2605.15225` link, matching the harness post's convention.
- **Dated update note** under the header: honest framing — the post is from April, the paper posted in May; notes the Gemma 4 27B e2e follow-up and the integrity/behavioral split.
- **Links list**: paper added as the first entry.

Closes Paper 4's external loop the way coredipper.github.io PR #8 did for Paper 5. Docs-only.

## Test plan

- [x] arXiv link + bib-accurate framing match operon PR #180's note
- [x] No duplicate post created; existing canonical post upgraded in place
- [ ] Pages rebuild after merge; arXiv link resolves in header + Links

🤖 Generated with [Claude Code](https://claude.com/claude-code)